### PR TITLE
Env checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,19 @@
 Envoi
 =====
-Environment variables on steroids
 
-Library to make environment variables more powerful
+Envoi aims to ease the use and documentation of environment variables (env
+vars) in PHP applications.
+
+Envoi features:
+
+- a Yaml schema to describe the env vars that may be used to configure an
+  application
+
+- tools to validate env vars against a schema
+
+- a tool to assist in the population of a `.env` file
+
+- a tool which converts a schema to markdown
 
 ### Install
 
@@ -11,6 +22,7 @@ Library to make environment variables more powerful
 ### Use
 
 #### Interpolation
+
 Assign one variable based on another in `.env` file
 
 ```
@@ -57,6 +69,6 @@ Available commands:
 Look for a `<!-- envoi start -->` and `<!-- envoi end -->` tags in file (default to README.md), and insert/update the generated markdown between those tags.
 
 
-##### Run tests
+### Run tests
     
     ./vendor/bin/phpunit --bootstrap vendor/autoload.php tests

--- a/README.md
+++ b/README.md
@@ -71,4 +71,4 @@ Look for a `<!-- envoi start -->` and `<!-- envoi end -->` tags in file (default
 
 ### Run tests
     
-    ./vendor/bin/phpunit --bootstrap vendor/autoload.php tests
+    ./vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -15,11 +15,48 @@ Envoi features:
 
 - a tool which converts a schema to markdown
 
+Envoi sports a console command which validates a `.env` file against a schema
+(by convention, `.env.yaml`).  It also provides checkers that, when invoked
+early in the start-up phase of an application, will halt an application which
+doesn't have a complete and valid set of env vars.
+
 ### Install
 
     composer require linkorb/envoi
 
 ### Use
+
+#### Env Checkers
+
+A checker should be invoked as early as possible in the life-cycle of an
+application.  The ideal time is immediately after the environment has been
+populated with env vars.  For example, in a Symfony-based app, the checker
+should be invoked right after the Dotenv component has loaded the env vars from
+the various `.env*` files:
+
+```
+<?php
+
+// config/bootstrap.php
+
+use Envoi\EnvChecker;
+use Symfony\Component\Dotenv\Dotenv;
+
+require dirname(__DIR__).'/vendor/autoload.php';
+
+(new Dotenv(false))->loadEnv(dirname(__DIR__).'/.env');
+// check the env!
+(new EnvChecker())->check(dirname(__DIR__).'/.env.yaml');
+```
+
+The checker will throw an exception to halt the application when invalid env
+vars are found.  The list of validation errors is included in the exception
+message.
+
+`EnvChecker` treats the environment as immutable: it validates env vars, but
+does not modify them.  `MutableEnvChecker` validates env vars and can also
+transform values, making it the ideal checker when you want to take advantage
+of the various env var transformation features of Envoi.
 
 #### Interpolation
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.5/phpunit.xsd"
+         processIsolation="true"
+         backupGlobals="true"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+>
+
+    <testsuites>
+        <testsuite name="unit-tests">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>src</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/EnvChecker.php
+++ b/src/EnvChecker.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Envoi;
+
+/**
+ * MutableEnvChecker checks the validity of environment variables.
+ */
+class EnvChecker
+{
+    /**
+     * Check the environment and complain loudly if invalid.
+     *
+     * @param string $path of the Yaml env file
+     *
+     * @throws \Envoi\InvalidEnvException
+     */
+    public function check(string $path): void
+    {
+        $errors = [];
+
+        $meta = $this->loadMeta($path);
+
+        // check that required vars are set and that set vars are valid
+        foreach ($meta as $varname => $metadata) {
+            try {
+                $this->validate($varname, $_ENV[$varname], $metadata);
+            } catch (InvalidEnvException $e) {
+                $errors[] = $e->getMessage();
+            }
+        }
+
+        foreach ($this->checkUndocumented($meta) as $varname => $_) {
+            $errors[] = "{$varname} is undocumented";
+        }
+
+        if (sizeof($errors)) {
+            throw new InvalidEnvException(implode('; ', $errors));
+        }
+    }
+
+    protected function loadMeta($path): array
+    {
+        return Envoi::metaFromYamlFile($path);
+    }
+
+    protected function validate($key, $value, $metadata)
+    {
+        return Envoi::validateValue($value, $key, $metadata);
+    }
+
+    protected function checkUndocumented(array $meta): array
+    {
+        if (!class_exists('\Symfony\Component\Dotenv\Dotenv')
+            || !isset($_ENV['SYMFONY_DOTENV_VARS'])
+        ) {
+            return [];
+        }
+
+        return array_diff_key(
+            array_flip(
+                explode(',', $_ENV['SYMFONY_DOTENV_VARS'])
+            ),
+            $meta
+        );
+    }
+}

--- a/src/MutableEnvChecker.php
+++ b/src/MutableEnvChecker.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Envoi;
+
+/**
+ * MutableEnvChecker checks the validity of environment variables and is able to
+ * modify the values according to their metadata.
+ */
+class MutableEnvChecker extends EnvChecker
+{
+    /**
+     * Check and adjust the environment and complain loudly if invalid.
+     *
+     * @param string $path of the Yaml env file
+     *
+     * @throws \Envoi\InvalidEnvException
+     */
+    public function check(string $path): void
+    {
+        $errors = $replacements = [];
+
+        $meta = $this->loadMeta($path);
+
+        // check that required vars are set and that set vars are valid
+        foreach ($meta as $varname => $metadata) {
+            try {
+                $replacementValue = $this->validate($varname, $_ENV[$varname], $metadata);
+                if ($_ENV[$varname] !== $replacementValue) {
+                    $replacements[$varname] = $replacementValue;
+                }
+            } catch (InvalidEnvException $e) {
+                $errors[] = $e->getMessage();
+            }
+        }
+
+        foreach ($this->checkUndocumented($meta) as $varname => $_) {
+            $errors[] = "{$varname} is undocumented";
+        }
+
+        if (sizeof($errors)) {
+            throw new InvalidEnvException(implode('; ', $errors));
+        }
+
+        foreach ($replacements as $varname => $value) {
+            $_ENV[$varname] = $value;
+        }
+    }
+}

--- a/tests/EnvCheckerTest.php
+++ b/tests/EnvCheckerTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace EnvoiTest;
+
+use Envoi\EnvChecker;
+use Envoi\Metadata;
+
+class EnvCheckerTest extends \PHPUnit\Framework\TestCase
+{
+    use EnvCheckerTestTrait;
+
+    protected $checker;
+
+    protected function setUp(): void
+    {
+        $this->checker = $this->getMockBuilder(EnvChecker::class)
+            ->setMethods(['loadMeta', 'validate'])
+            ->getMock();
+    }
+
+    public function testCheckWillNotAlterTheEnvironment()
+    {
+        $_ENV['X_TESTVAR'] = $expectedVarValue = 'String!';
+
+        $meta = [
+            'X_TESTVAR' => $this->makeMetadata(Metadata::TYPE_STRING),
+        ];
+
+        $this->checker
+            ->method('loadMeta')
+            ->willReturn($meta)
+        ;
+        $this->checker
+            ->method('validate')
+            ->with('X_TESTVAR', $expectedVarValue, $meta['X_TESTVAR'])
+            ->willReturn('altered String!')
+        ;
+
+        $this->checker->check('path/to/.env.yaml');
+
+        $this->assertSame(
+            $expectedVarValue,
+            $_ENV['X_TESTVAR'],
+            'The value of X_TESTVAR was not modified by EnvChecker.'
+        );
+    }
+}

--- a/tests/EnvCheckerTestTrait.php
+++ b/tests/EnvCheckerTestTrait.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace EnvoiTest;
+
+use Envoi\InvalidEnvException;
+use Envoi\Metadata;
+
+trait EnvCheckerTestTrait
+{
+    public function testCheckWillLoadMetaFromTheSuppliedPath()
+    {
+        $this->checker
+            ->expects($this->once())
+            ->method('loadMeta')
+            ->with('path/to/.env.yaml')
+            ->willReturn([])
+        ;
+
+        $this->checker->check('path/to/.env.yaml');
+    }
+
+    public function testCheckWillThrowExceptionListingErrorsWhenValidationFails()
+    {
+        // Expect an exception that contains the validation failure message
+        $this->expectException(InvalidEnvException::class);
+        $this->expectExceptionMessage('IT IS NOT A STRING');
+
+        $_ENV['X_TESTVAR'] = 'Ceci n\'est pas une chaîne';
+
+        $meta = [
+            'X_TESTVAR' => $this->makeMetadata(Metadata::TYPE_STRING),
+        ];
+
+        $this->checker
+            ->method('loadMeta')
+            ->willReturn($meta)
+        ;
+        $this->checker
+            ->expects($this->once())
+            ->method('validate')
+            ->with('X_TESTVAR', 'Ceci n\'est pas une chaîne', $meta['X_TESTVAR'])
+            ->willThrowException(new InvalidEnvException('Fail: IT IS NOT A STRING'))
+        ;
+
+        $this->checker->check('path/to/.env.yaml');
+    }
+
+    public function testCheckWillReturnWhenValidationSucceeds()
+    {
+        $_ENV['X_TESTVAR'] = 'String!';
+
+        $meta = [
+            'X_TESTVAR' => $this->makeMetadata(Metadata::TYPE_STRING),
+        ];
+
+        $this->checker
+            ->method('loadMeta')
+            ->willReturn($meta)
+        ;
+        $this->checker
+            ->expects($this->once())
+            ->method('validate')
+            ->with('X_TESTVAR', 'String!', $meta['X_TESTVAR'])
+        ;
+
+        $this->checker->check('path/to/.env.yaml');
+    }
+
+    protected function makeMetadata($type)
+    {
+        $m = new Metadata();
+        $m->type = $type;
+        $m->description = '';
+        $m->required = false;
+        $m->default = null;
+        $m->example = '';
+        $m->makeAbsolutePath = false;
+        $m->options = null;
+
+        return $m;
+    }
+}

--- a/tests/MutableEnvCheckerTest.php
+++ b/tests/MutableEnvCheckerTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace EnvoiTest;
+
+use Envoi\Metadata;
+use Envoi\MutableEnvChecker;
+
+class MutableEnvCheckerTest extends \PHPUnit\Framework\TestCase
+{
+    use EnvCheckerTestTrait;
+
+    protected $checker;
+
+    protected function setUp(): void
+    {
+        $this->checker = $this->getMockBuilder(MutableEnvChecker::class)
+            ->setMethods(['checkUndocumented', 'loadMeta', 'validate'])
+            ->getMock();
+    }
+
+    public function testCheckWillAlterTheEnvironment()
+    {
+        $_ENV['X_TESTVAR'] = $initialVarValue = 'String!';
+
+        $meta = [
+            'X_TESTVAR' => $this->makeMetadata(Metadata::TYPE_STRING),
+        ];
+
+        $this->checker
+            ->method('loadMeta')
+            ->willReturn($meta)
+        ;
+        $this->checker
+            ->method('validate')
+            ->with('X_TESTVAR', $initialVarValue, $meta['X_TESTVAR'])
+            ->willReturn('altered String!')
+        ;
+
+        $this->checker->check('path/to/.env.yaml');
+
+        $this->assertSame(
+            'altered String!',
+            $_ENV['X_TESTVAR'],
+            'The value of X_TESTVAR was modified by EnvChecker.'
+        );
+    }
+}


### PR DESCRIPTION
## Proposed changes

Make it possible to halt a symfony-based app when env vars aren't valid.

Either of two classes, `EnvChecker` or `MutableEnvChecker`, can be invoked early in the app life-cycle to validate its env vars and throw an exception if validation fails.  In a modern symfony app, the following halt the app and console commands:

```php
// config/bootstrap.php
use Envoi\MutableEnvChecker;
use Symfony\Component\Dotenv\Dotenv;

require dirname(__DIR__).'/vendor/autoload.php';

// load all the .env files
(new Dotenv(false))->loadEnv(dirname(__DIR__).'/.env');
// check all the env vars
(new MutableEnvChecker())->check(dirname(__DIR__).'/.env.yaml');
```

The `check` method throws an exception to halt the app before it even boots.

Fixes #3.

## Types of changes

This is a new feature (non-breaking change which adds functionality).