### PR TITLE
Fail Louder

### DIFF
--- a/src/Command/MarkdownCommand.php
+++ b/src/Command/MarkdownCommand.php
@@ -33,10 +33,28 @@ class MarkdownCommand extends Command
         $markdownFile = $input->getArgument('markdownFile');
         $envMetaFile = $input->getArgument('envMetaFile');
 
-        if (Envoi::markdown($envMetaFile, $markdownFile)) {
-            $output->writeln(sprintf('<info>File %s was success changed</info>', $markdownFile));
-        } else {
-            $output->writeln(sprintf('<error>File %s have not envoi tags</error>', $markdownFile));
+        $docWasWritten = false;
+
+        try {
+            $docWasWritten = Envoi::markdown($envMetaFile, $markdownFile);
+        } catch (\UnexpectedValueException $e) {
+            $output->writeln("<comment>There wasn't any Env Var Metadata to document in the meta file \"{$envMetaFile}\".</comment>");
+
+            return -1;
+        } catch (\InvalidArgumentException $e) {
+            $output->writeln("<error>The path to the markdownFile \"{$markdownFile}\" is not valid: \"{$e->getMessage()}\".</error>");
+
+            return -1;
         }
+
+        if (!$docWasWritten) {
+            $output->writeln("<error>The Env Var documentation was not written to the markdownFile \"{$markdownFile}\".  Please check that the file contains the required Envoi tags.</error>");
+
+            return -1;
+        }
+
+        $output->writeln("<info>The Env Var documentation was successfully written to \"{$markdownFile}\".</info>");
+
+        return 0;
     }
 }

--- a/src/EnvChecker.php
+++ b/src/EnvChecker.php
@@ -3,7 +3,7 @@
 namespace Envoi;
 
 /**
- * MutableEnvChecker checks the validity of environment variables.
+ * EnvChecker checks the validity of environment variables.
  */
 class EnvChecker
 {

--- a/src/EnvChecker.php
+++ b/src/EnvChecker.php
@@ -23,7 +23,7 @@ class EnvChecker
         // check that required vars are set and that set vars are valid
         foreach ($meta as $varname => $metadata) {
             try {
-                $this->validate($varname, $_ENV[$varname], $metadata);
+                $this->validate($varname, $_ENV[$varname] ?? '', $metadata);
             } catch (InvalidEnvException $e) {
                 $errors[] = $e->getMessage();
             }

--- a/src/EnvChecker.php
+++ b/src/EnvChecker.php
@@ -33,9 +33,7 @@ class EnvChecker
             $errors[] = "{$varname} is undocumented";
         }
 
-        if (sizeof($errors)) {
-            throw new InvalidEnvException(implode('; ', $errors));
-        }
+        $this->complain($errors);
     }
 
     protected function loadMeta($path): array
@@ -62,5 +60,14 @@ class EnvChecker
             ),
             $meta
         );
+    }
+
+    protected function complain(array $errors): void
+    {
+        if (0 === sizeof($errors)) {
+            return;
+        }
+
+        throw new InvalidEnvException(implode('; ', $errors));
     }
 }

--- a/src/Envoi.php
+++ b/src/Envoi.php
@@ -167,7 +167,7 @@ class Envoi
         $meta = self::metaFromYamlFile($envMetaPath);
 
         if (count($meta) === 0) {
-            return false;
+            throw new \UnexpectedValueException("Expected there to be metadata in the meta file \"{$envMetaPath}\", but found none.");
         }
 
         if (!is_file($markdownFile)) {

--- a/src/MutableEnvChecker.php
+++ b/src/MutableEnvChecker.php
@@ -37,9 +37,7 @@ class MutableEnvChecker extends EnvChecker
             $errors[] = "{$varname} is undocumented";
         }
 
-        if (sizeof($errors)) {
-            throw new InvalidEnvException(implode('; ', $errors));
-        }
+        $this->complain($errors);
 
         foreach ($replacements as $varname => $value) {
             $_ENV[$varname] = $value;


### PR DESCRIPTION
This is a draft because I've not yet been able to test this in a production setting.  If you can test it, please do!

The interesting commit is b03b098. It registers an exception handler that will catch an InvalidEnvException, output a message to the browser and, finally, trigger an error in much the same way that the default PHP exception handler does.

So this means there should be a message in the browser and (depending on php configuration) an exception in the error log.

This message won't be sent to output when PHP is running as cli.  It won't be sent if a custom exception handler is already registered so that it won't interfere with any alternative error handler arrangements. It won't be sent if the developer decides to handle the InvalidEnvException in some other way.

Taking advantage of this message-to-the-browser feature requires no extra steps - simply install this version of envoi.