### PR TITLE
The validate command should report the same result as Dotenv.loadEnv() followed by EnvChecker.check()

### DIFF
--- a/src/ConsoleFactory.php
+++ b/src/ConsoleFactory.php
@@ -25,7 +25,7 @@ class ConsoleFactory
         $application->getHelperSet()->set(new QuestionHelper());
 
         $application->add(new ConfigureCommand());
-        $application->add(new ValidateCommand());
+        $application->add(new ValidateCommand(new EnvChecker()));
         $application->add(new MarkdownCommand());
 
         return $application;


### PR DESCRIPTION
This is achieved by calling:

- calling Dotenv.loadEnv, from the validate command, to populate the environment
- injecting EnvChecker into the validate command and calling its check() method

Additionally, EnvChecker.check() examines env vars in $_SERVER which helps to catch those cases where an env var is set outside of PHP and is not copied to the $_ENV global by Dotenv, but is copied to $_SERVER by the PHP interpreter.